### PR TITLE
MVCE for issue 8203 ORA-01745 executing a SELECT * FROM WHERE column IN (large collection)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,18 @@
         <db.url>jdbc:h2:~/mcve</db.url>
         <db.username>sa</db.username>
         <db.password></db.password>
+        <!--
+        <db.url>jdbc:oracle:thin:@localhost:1521:xe</db.url>
+        <db.username>system</db.username>
+        <db.password>oracle</db.password>
+        -->
     </properties>
 
     <dependencies>
 
         <!-- Database access -->
         <dependency>
-            <groupId>org.jooq</groupId>
+            <groupId>org.jooq.pro</groupId>
             <artifactId>jooq</artifactId>
             <version>${org.jooq.version}</version>
         </dependency>
@@ -28,6 +33,11 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>1.4.197</version>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <version>12.2.0.1</version>
         </dependency>
 
         <!-- Logging -->
@@ -53,8 +63,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>10</source>
-                    <target>10</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/src/main/resources/db/migration/V0__initialize_oracle.sql
+++ b/src/main/resources/db/migration/V0__initialize_oracle.sql
@@ -1,0 +1,17 @@
+CREATE USER mcve
+  IDENTIFIED BY oracle
+  DEFAULT TABLESPACE users
+  QUOTA 20M on users;
+
+GRANT create session TO mcve;
+GRANT create table TO mcve;
+GRANT create view TO mcve;
+GRANT create any trigger TO mcve;
+GRANT create any procedure TO mcve;
+GRANT create sequence TO mcve;
+GRANT create synonym TO mcve;
+
+CREATE TABLE mcve.test (
+    id    NUMBER(10) NOT NULL,
+    value NUMBER(10));
+ALTER TABLE mcve.test ADD (CONSTRAINT test_pk PRIMARY KEY (ID));


### PR DESCRIPTION
### Expected behavior and actual behavior: 

Expected behavior is that the following code executes without error and returns the relevant results.
```
    Collection<Long> ids = // collection larger than 65535 elements
    ctx.select(DSL.count()).from(TEST)
        .where(TEST.ID.in(ids))
        .fetchOne(0, int.class);
```

Actual behavior is that if one uses jooq to perform WHERE IN with a large collection (larger than 65535 elements) on Oracle, this results in `ORA-01745: invalid host/bind variable name`.

### Steps to reproduce the problem: https://github.com/schlosna/jOOQ-mcve/pull/1

### Versions:

- jOOQ: 3.11.2 pro
- Java: 8u181
- Database (include vendor): Oracle 12.1
- OS: CentOS 7 Linux 
- JDBC Driver (include name if inofficial driver): ojdbc8 thin
